### PR TITLE
Issue when rendering if a option has a '-' in  a Jinja2 template.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,18 +2,18 @@
 amplecode.recipe.template
 =========================
 
-amplecode.recipe.template is a Buildout recipe for generating files using Jinja2 templates. The recipe configures a Jinja2 environment, by default relative to the Buildout directory, allowing templates to extend and include other templates relative to the environment. 
+amplecode.recipe.template is a Buildout recipe for generating files using Jinja2 templates. The recipe configures a Jinja2 environment, by default relative to the Buildout directory, allowing templates to extend and include other templates relative to the environment.
 
 Downloads are available from pypi: http://pypi.python.org/pypi/amplecode.recipe.template/
 
 Buildout Options
 ================
 
-* template-file (required): One or more Jinja2 template file paths. 
-* target-file (required): One of more target file paths. The number of files must match the number of template files. 
-* base-dir: Base directory of the Jinja2 environment. Template file paths are relative to this directory. Default is the Buildout directory. 
-* target-executable: One or more boolean flags (yes|no|true|false|1|0) indicating the executability of the target files. If only one flag is given it is applied to all target files. 
-* eggs: Reserved for a list of eggs, conveniently converted into a pkg_resources.WorkingSet when specified 
+* template-file (required): One or more Jinja2 template file paths.
+* target-file (required): One of more target file paths. The number of files must match the number of template files.
+* base-dir: Base directory of the Jinja2 environment. Template file paths are relative to this directory. Default is the Buildout directory.
+* target-executable: One or more boolean flags (yes|no|true|false|1|0) indicating the executability of the target files. If only one flag is given it is applied to all target files.
+* eggs: Reserved for a list of eggs, conveniently converted into a pkg_resources.WorkingSet when specified
 
 Additional options are simply forwarded to the templates, and options from all the other parts listed in buildout:parts are made available through ``parts.<part-name>.<option-name>`` and ``parts[<part-name>][<option-name>]``.
 

--- a/amplecode/recipe/template/__init__.py
+++ b/amplecode/recipe/template/__init__.py
@@ -34,11 +34,11 @@ class Recipe(object):
         self.options = options
 
         # Validate presence of required options
-        if not "template-file" in options:
-            log.error("You need to specify a template-file")
+        if not ("template-file" in options or "input" in options):
+            log.error("You need to specify a template-file or input")
             raise zc.buildout.UserError("No template file specified")
-        if not "target-file" in options:
-            log.error("You need to specify a target-file")
+        if not ("target-file" in options or "output" in options):
+            log.error("You need to specify a target-file or output")
             raise zc.buildout.UserError("No target file specified")
 
     def install(self):
@@ -73,8 +73,16 @@ class Recipe(object):
             return d
 
         # Validate template and target lists
-        template_files = split(self.options["template-file"])
-        target_files = split(self.options["target-file"])
+        template_file_option = self.options.get(
+                "template-file",
+                self.options.get("input")
+                )
+        target_file_option = self.options.get(
+                "target-file",
+                self.options.get("output")
+                )
+        template_files = split(template_file_option)
+        target_files = split(target_file_option)
         if len(template_files) != len(target_files):
             raise zc.buildout.UserError(
                     "The number of template and target files must match")


### PR DESCRIPTION
i have problem when rendering the option 'target-file'.
So the recipe is aware of 'input' ('template-file') and 'output' ('target-file') option as well.
