### PR TITLE
Access to all parts not just the one in specified in the parts option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,20 +2,20 @@
 amplecode.recipe.template
 =========================
 
-amplecode.recipe.template is a Buildout recipe for generating files using Jinja2 templates. The recipe configures a Jinja2 environment, by default relative to the Buildout directory, allowing templates to extend and include other templates relative to the environment. 
+amplecode.recipe.template is a Buildout recipe for generating files using Jinja2 templates. The recipe configures a Jinja2 environment, by default relative to the Buildout directory, allowing templates to extend and include other templates relative to the environment.
 
 Downloads are available from pypi: http://pypi.python.org/pypi/amplecode.recipe.template/
 
 Buildout Options
 ================
 
-* template-file (required): One or more Jinja2 template file paths. 
-* target-file (required): One of more target file paths. The number of files must match the number of template files. 
-* base-dir: Base directory of the Jinja2 environment. Template file paths are relative to this directory. Default is the Buildout directory. 
-* target-executable: One or more boolean flags (yes|no|true|false|1|0) indicating the executability of the target files. If only one flag is given it is applied to all target files. 
-* eggs: Reserved for a list of eggs, conveniently converted into a pkg_resources.WorkingSet when specified 
+* template-file (required): One or more Jinja2 template file paths.
+* target-file (required): One of more target file paths. The number of files must match the number of template files.
+* base-dir: Base directory of the Jinja2 environment. Template file paths are relative to this directory. Default is the Buildout directory.
+* target-executable: One or more boolean flags (yes|no|true|false|1|0) indicating the executability of the target files. If only one flag is given it is applied to all target files.
+* eggs: Reserved for a list of eggs, conveniently converted into a pkg_resources.WorkingSet when specified
 
-Additional options are simply forwarded to the templates, and options from all the other parts listed in buildout:parts are made available through ``parts.<part-name>.<option-name>`` and ``parts[<part-name>][<option-name>]``.
+Additional options are simply forwarded to the templates, and options from all the other parts are made available through ``parts.<part-name>.<option-name>`` and ``parts[<part-name>][<option-name>]``.
 
 Lists of Values
 ===============

--- a/amplecode/recipe/template/__init__.py
+++ b/amplecode/recipe/template/__init__.py
@@ -104,11 +104,8 @@ class Recipe(object):
             names, eggs = eggs.working_set()
             context["eggs"] = eggs
 
-        # Make options from other parts available. The parts include the
-        # buildout part and all parts specified in the buildout part.
-        part_options = {}
-        for part in ['buildout'] + split(self.buildout["buildout"]["parts"]):
-            part_options[part] = strip_dict(dict(self.buildout[part].items()))
+        # Make options from other parts available.
+        part_options = self.buildout
         if 'parts' not in context.keys():
             context.update({'parts': part_options})
         else:


### PR DESCRIPTION
I like to have some parts without recipes, like:

[ips]
server = 192.168.56.1

And I would find it useful to access them in the template.
I thing it is more natural to. 
In buildout you can access the parts that are not defined in the parts option.
Another problem is that if you want to add a part to the parts option you need a recipe. That in my case would do nothing.

That change shouldn't brake the old behavior. 
